### PR TITLE
Script: Render all cameras in a blender file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Content
 | Folder                   | Content                                      |
 |--------------------------|----------------------------------------------|
 | music                    | Scores/Sheet Music                           |
+| scripts                  | Helpful scripts                              |
 
 
 License

--- a/copying.md
+++ b/copying.md
@@ -14,6 +14,7 @@ _the openage authors_ are:
 |--------------------------------|------------------------------|-----------------------------------------------|
 | Jonas Jelten                   | TheJJ                        | jj à sft dawt mx                              |
 | Jonathan Shaw                  | Zalladi                      | inspectorjshaw à gmail dawt com               |
+| Christoph Heine                | heinezen                     | heinezen à mailbox dawt org                   |
 
 
 If you're a first-time commiter, add yourself to the above list. This is not

--- a/scripts/blender/create_sprites.py
+++ b/scripts/blender/create_sprites.py
@@ -1,0 +1,60 @@
+# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+#
+# Usage for this script:
+#  blender --background --python create_sprites.py -- \
+#          --cameras Camera0,Camera90,Camera180 \
+#
+
+import sys, bpy, argparse
+
+# This part is necessary to pass arguments to the python script.
+# Blender ignores every argument after "--".
+argv = sys.argv
+
+if "--" not in argv:
+    argv = []
+else:
+    argv = argv[argv.index("--") + 1:]
+
+# Parsing arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--cameras", 
+                    help=("only render cameras with these names; "
+                        "separate by using ','"))
+args = parser.parse_args(argv)
+
+cameras = []
+
+if args.cameras is not None:
+    cameras = args.cameras.split(",")
+    print(cameras)
+
+index = 0
+
+for obj in bpy.data.objects:
+    
+    if obj.type == 'CAMERA' and (len(cameras) == 0 
+                                 or obj.name in cameras):
+        print("Creating sprite for", obj.name)
+
+        bpy.context.scene.camera = obj
+        
+        #Set camera to orthographic
+        obj.data.type = 'ORTHO'
+        
+        #Set file format to PNG if that wasn't default
+        bpy.context.scene.render.image_settings.file_format = 'PNG'
+        
+        #Set background to alpha channel  
+        bpy.context.scene.render.alpha_mode = 'TRANSPARENT' 
+        bpy.context.scene.render.image_settings.color_mode ='RGBA'
+        
+        #Save image file
+        filename = bpy.path.basename(bpy.data.filepath)
+        filename = filename.split('.')[0]
+        path = '//' + filename + '/' + filename + '_' + str(index)
+        bpy.context.scene.render.filepath = path 
+
+        bpy.ops.render.render(write_still=True)
+        
+        index += 1

--- a/scripts/blender/create_sprites.py
+++ b/scripts/blender/create_sprites.py
@@ -18,7 +18,7 @@ else:
 
 # Parsing arguments
 parser = argparse.ArgumentParser()
-parser.add_argument("-c", "--cameras", 
+parser.add_argument("-c", "--cameras",
                     help=("only render cameras with these names; "
                         "separate by using ','"))
 args = parser.parse_args(argv)
@@ -33,28 +33,28 @@ index = 0
 
 for obj in bpy.data.objects:
     
-    if obj.type == 'CAMERA' and (len(cameras) == 0 
+    if obj.type == 'CAMERA' and (not cameras
                                  or obj.name in cameras):
         print("Creating sprite for", obj.name)
 
         bpy.context.scene.camera = obj
-        
-        #Set camera to orthographic
+
+        # Set camera to orthographic
         obj.data.type = 'ORTHO'
         
-        #Set file format to PNG if that wasn't default
+        # Set file format to PNG if that wasn't default
         bpy.context.scene.render.image_settings.file_format = 'PNG'
         
-        #Set background to alpha channel  
+        # Set background to alpha channel
         bpy.context.scene.render.alpha_mode = 'TRANSPARENT' 
         bpy.context.scene.render.image_settings.color_mode ='RGBA'
         
-        #Save image file
+        # Save image file
         filename = bpy.path.basename(bpy.data.filepath)
         filename = filename.split('.')[0]
         path = '//' + filename + '/' + filename + '_' + str(index)
         bpy.context.scene.render.filepath = path 
 
         bpy.ops.render.render(write_still=True)
-        
+
         index += 1


### PR DESCRIPTION
This script renders the camera perspectives of a Blender file and outputs them to a subfolder as `.png` images. It optionally supports rendering only a subset of the cameras, which can be specified by using `-c <camera_name1>,<camera_name2>,..`.

Since we have no blender assets ready yet, I provided an example file with 4 cameras and Blender's Suzanne mesh for testing.

[example.zip](https://github.com/SFTtech/openage-modding/files/1422009/example.zip)
